### PR TITLE
Reapply SAM Profile and Use cfgutil

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,8 @@ dist
 
 # TernJS port file
 .tern-port
+
+config.json
+.DS_Store
+org.crt
+org.der

--- a/README.md
+++ b/README.md
@@ -10,7 +10,10 @@
 7.) Install latest `libplist` `brew install --HEAD libplist`   
 8.) Install latest `libimobiledevice` `brew install --HEAD libimobiledevice`  
 9.) Install `ideviceinstaller` `brew install ideviceinstaller`  
-10.) Install `ios-deploy` `brew install ios-deploy`  
+10.) Navigate to the App Store and download/install Apple Configurator 2 (AC2).
+11.) In AC2, click on the `Apple Configurator 2` menu and choose `Install Automation Tools`.
+12.) In AC2, click on the `Apple Configurator 2` menu and choose `Preferences` > `Organization` > click on your org and choose `Export Supervision Identity` in the bottom left.
+13.) Move the .crt and .der files to the DCMRemoteListener folder and rename them to `org.crt` and `org.der`.
 
 ## Installation  
 1.) Clone repository `git clone https://github.com/versx/DCMRemoteListener`  
@@ -26,3 +29,6 @@
 
 ## Discord  
 https://discordapp.com/invite/zZ9h9Xa  
+
+## Troubleshooting
+If the cfgutil from AC2 does not list any devices when you use the `cfgutil list` command, then you may need to upgrade AC2 and reinstall the automation tools.

--- a/listener.js
+++ b/listener.js
@@ -113,12 +113,12 @@ function cli_exec(command,type){
                   device_object.ipaddr = await cli_exec("ping -t 1 "+device_object.name,'device_ipaddr');
                   if(device_object.ipaddr == ''){
                     // Look for tethered addresses and blanks. This takes a while
-                    device_object.ipaddr = await cli_exec("idevicesyslog -u "+device_object.uuid+" -m 'flow path=satisfied (Path is satisfied)' -T 'flow path'",'device_ipaddr');
+                    device_object.ipaddr = await cli_exec("grep -A1 \""+device_object.name.replace('+', '.*')+"\" /var/db/dhcpd_leases", 'device_ipaddr');
                   }
                   devices.push(device_object);
                   console.log("[DCM] [listener.js] ["+getTime("log")+"] Found Device:", device_object);
                 }
-                if(counter >= data.length -1){
+                if(counter >= Object.keys(data).length -1){
                   resolve();
                 } else {
                   counter++
@@ -145,12 +145,12 @@ function cli_exec(command,type){
               let ip_line = '';
               let log_data = stdout.split("\n");
               for(var line of log_data){
-                if(line.includes("<->IPv4")){
+                if(line.includes("ip_address")){
                   ip_line = line;
                   break;
                 }
               }
-              let ip_strings = ip_line.split(/ |:/);
+              let ip_strings = ip_line.split("=");
               for(var line of ip_strings){
                 if(line.includes("192.168.")){
                   ipaddr = line;

--- a/sam_clock.mobileconfig
+++ b/sam_clock.mobileconfig
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>App</key>
+			<dict>
+				<key>Identifier</key>
+				<string>com.apple.mobiletimer</string>
+				<key>Options</key>
+				<dict>
+					<key>DisableAutoLock</key>
+					<true/>
+					<key>DisableDeviceRotation</key>
+					<true/>
+					<key>DisableSleepWakeButton</key>
+					<true/>
+				</dict>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures Single App Mode</string>
+			<key>PayloadDisplayName</key>
+			<string>Single App Mode</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.app.lock.EA7F2FEE-F023-41E7-BC33-BAA2091A516E</string>
+			<key>PayloadType</key>
+			<string>com.apple.app.lock</string>
+			<key>PayloadUUID</key>
+			<string>EA7F2FEE-F023-41E7-BC33-BAA2091A516E</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Start Clock in Single App Mode</string>
+	<key>PayloadDisplayName</key>
+	<string>sam_clock</string>
+	<key>PayloadIdentifier</key>
+	<string>com.apple.configurator.singleappmode</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>4B19773B-AE98-4026-99C3-0228D35F7EC6</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>

--- a/sam_pogo.mobileconfig
+++ b/sam_pogo.mobileconfig
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>PayloadContent</key>
+	<array>
+		<dict>
+			<key>App</key>
+			<dict>
+				<key>Identifier</key>
+				<string>com.nianticlabs.pokemongo</string>
+				<key>Options</key>
+				<dict>
+					<key>DisableAutoLock</key>
+					<true/>
+					<key>DisableDeviceRotation</key>
+					<true/>
+					<key>DisableSleepWakeButton</key>
+					<true/>
+				</dict>
+			</dict>
+			<key>PayloadDescription</key>
+			<string>Configures Single App Mode</string>
+			<key>PayloadDisplayName</key>
+			<string>Single App Mode</string>
+			<key>PayloadIdentifier</key>
+			<string>com.apple.app.lock.EA7F2FEE-F023-41E7-BC33-BAA2091A516E</string>
+			<key>PayloadType</key>
+			<string>com.apple.app.lock</string>
+			<key>PayloadUUID</key>
+			<string>EA7F2FEE-F023-41E7-BC33-BAA2091A516E</string>
+			<key>PayloadVersion</key>
+			<integer>1</integer>
+		</dict>
+	</array>
+	<key>PayloadDescription</key>
+	<string>Start Pokemon Go in Single App Mode</string>
+	<key>PayloadDisplayName</key>
+	<string>sam_pogo</string>
+	<key>PayloadIdentifier</key>
+	<string>com.apple.configurator.singleappmode</string>
+	<key>PayloadScope</key>
+	<string>System</string>
+	<key>PayloadType</key>
+	<string>Configuration</string>
+	<key>PayloadUUID</key>
+	<string>4B19773B-AE98-4026-99C3-0228D35F7EC6</string>
+	<key>PayloadVersion</key>
+	<integer>1</integer>
+</dict>
+</plist>


### PR DESCRIPTION
Update to accept request types of `profile` to reapply the SAM profile to a requested phone. This is setup to remove the original one, apply a SAM for Clock, remove it, and then apply the SAM for pogo.

Changed the parsing to use the cfgutil to get the name, UUID, and ECID. Also, found where tethered IPs are stored in a db so I changed this to read those IPs instead of the syslog.

This is also in reference to the info posted in https://github.com/versx/iPhoneController/issues/7 but with different profiles.