### PR TITLE
Support for Brightness Control

### DIFF
--- a/listener.js
+++ b/listener.js
@@ -120,6 +120,28 @@ server.post("/", (payload, res) => {
           res.json({ status: 'ok' });
         }
         break;
+
+      // CHANGE DEVICE BRIGHTNESS
+      case "brightness":
+        if(device.name == target.device){
+          let brightness = await cli_exec("curl -X POST http://"+device.ipaddr+":8080/brightness?value="+target.value,"device_command");
+
+          // THERE WAS AN ERROR WITH CURL
+          if(brightness.hasError){
+            console.error("[DCM] [listener.js] ["+getTime("log")+"] Failed to change brightness for "+device.name+" : "+device.uuid+".",response.error);
+
+            // SEND ERROR TO DCM
+            res.json({ status: 'error', node: config.name, error:'Failed to change device brightness.' });
+
+          // CHANGE WAS SUCCESSFUL
+          } else {
+            console.log("[DCM] [listener.js] ["+getTime("log")+"] Device brightness was changed to "+target.value+"% for "+device.name+" : "+device.uuid+".");
+
+            // SEND CONFIRMATION TO DCM
+            res.json({ status: 'ok' });
+          }
+        }
+        break;
     }
   }); return;
 });


### PR DESCRIPTION
This updates supports the brightness payload from RDM Monitor's PR [#13](https://github.com/Kneckter/RDMMonitor/pull/13). No config changes needed and works with wifi or tethered devices. 