### PR TITLE
Ad-hoc IP Gathering and Support Manual Device List

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 7.) Install latest `libplist` `brew install --HEAD libplist`   
 8.) Install latest `libimobiledevice` `brew install --HEAD libimobiledevice`  
 9.) Install `ideviceinstaller` `brew install ideviceinstaller`  
-10.) Navigate to the App Store and download/install Apple Configurator 2 (AC2).
-11.) In AC2, click on the `Apple Configurator 2` menu and choose `Install Automation Tools`.
-12.) In AC2, click on the `Apple Configurator 2` menu and choose `Preferences` > `Organization` > click on your org and choose `Export Supervision Identity` in the bottom left.
-13.) Move the .crt and .der files to the DCMRemoteListener folder and rename them to `org.crt` and `org.der`.
+10.) Navigate to the App Store and download/install Apple Configurator 2 (AC2)
+11.) In AC2, click on the `Apple Configurator 2` menu and choose `Install Automation Tools`
+12.) In AC2, click on the `Apple Configurator 2` menu and choose `Preferences` > `Organization` > click on your org and choose `Export Supervision Identity` in the bottom left
+13.) Move the .crt and .der files to the DCMRemoteListener folder and rename them to `org.crt` and `org.der`
 
 ## Installation  
 1.) Clone repository `git clone https://github.com/versx/DCMRemoteListener`  
@@ -26,6 +26,15 @@
   * Domain (i.e. `http://10.0.0.2:9991` or `https://dcm.domain.com`) is the DeviceConfigManager domain that will be sending the reboot request, otherwise set to `*` to accept from all hosts.
 
 6.) Start the bot with `pm2 start listener.js` or `node listener.js` if not using pm2  
+
+## Config Options
+```
+"name" = The name you want to use for this server.
+"port" = The inbound TCP port for requests.
+"domain" = The domain that is allowed to send requests.
+"manual_list" = True/False for creating your own JSON list of devices as device.json. See device.example.json.
+"manual_ip" = True/False for adding the IP to the device.json or to allow the script to find IPs.
+```
 
 ## Discord  
 https://discordapp.com/invite/zZ9h9Xa  

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@
 7.) Install latest `libplist` `brew install --HEAD libplist`   
 8.) Install latest `libimobiledevice` `brew install --HEAD libimobiledevice`  
 9.) Install `ideviceinstaller` `brew install ideviceinstaller`  
-10.) Navigate to the App Store and download/install Apple Configurator 2 (AC2)
-11.) In AC2, click on the `Apple Configurator 2` menu and choose `Install Automation Tools`
-12.) In AC2, click on the `Apple Configurator 2` menu and choose `Preferences` > `Organization` > click on your org and choose `Export Supervision Identity` in the bottom left
-13.) Move the .crt and .der files to the DCMRemoteListener folder and rename them to `org.crt` and `org.der`
+10.) Navigate to the App Store and download/install Apple Configurator 2 (AC2)<br>
+11.) In AC2, click on the `Apple Configurator 2` menu and choose `Install Automation Tools`<br>
+12.) In AC2, click on the `Apple Configurator 2` menu and choose `Preferences` > `Organization` > click on your org and choose `Export Supervision Identity` in the bottom left<br>
+13.) Move the .crt and .der files to the DCMRemoteListener folder and rename them to `org.crt` and `org.der`<br>
 
 ## Installation  
 1.) Clone repository `git clone https://github.com/versx/DCMRemoteListener`  

--- a/config.example.json
+++ b/config.example.json
@@ -1,5 +1,7 @@
 {
     "name": "Scanner 1",
     "port": 6542,
-    "domain": "http://YOUR-DOMAIN.TLD"
+    "domain": "http://YOUR-DOMAIN.TLD",
+    "manual_list": false,
+    "manual_ip": false
 }

--- a/devices.example.json
+++ b/devices.example.json
@@ -1,0 +1,14 @@
+[
+  {
+    "name":"001-SE",
+    "uuid":"f0axxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx9af",
+    "ecid":"0x9000000000006",
+    "ipaddr":"192.168.1.1"
+  },
+  {
+    "name":"002-SE",
+    "uuid":"f0axxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx9af",
+    "ecid":"0x9000000000006",
+    "ipaddr":"192.168.1.2"
+  }
+]

--- a/listener.js
+++ b/listener.js
@@ -57,10 +57,9 @@ server.post("/", (payload, res) => {
                             node: config.name,
                             error: 'Failed to restart device.'
                         });
-
-                        // RESTART WAS SUCCESSFUL
                     }
                     else {
+                        // RESTART WAS SUCCESSFUL
                         console.log("[DCM] [listener.js] [" + getTime("log") + "] Restarted " + device.name + " : " + device.uuid + ".");
 
                         // SEND CONFIRMATION TO DCM
@@ -71,7 +70,7 @@ server.post("/", (payload, res) => {
                 }
                 break;
 
-                // REOPEN THE GAME
+            // REOPEN THE GAME
             case "reopen":
                 if (device.name == target.device) {
                     var ipaddr = '';
@@ -104,10 +103,9 @@ server.post("/", (payload, res) => {
                             node: config.name,
                             error: 'Failed to reopen game.'
                         });
-
-                        // RESTART WAS SUCCESSFUL
                     }
                     else {
+                        // RESTART WAS SUCCESSFUL
                         console.log("[DCM] [listener.js] [" + getTime("log") + "] Reopened the game for " + device.name + " : " + device.uuid + ".");
 
                         // SEND CONFIRMATION TO DCM
@@ -118,7 +116,7 @@ server.post("/", (payload, res) => {
                 }
                 break;
 
-                // REAPPLY THE SAM PROFILE
+            // REAPPLY THE SAM PROFILE
             case "profile":
                 if (device.name == target.device) {
                     // REMOVE THE SAM PROFILE
@@ -218,7 +216,7 @@ function cli_exec(command, type) {
                                     resolve();
                                 }
                                 else {
-                                    counter++
+                                    counter++;
                                 }
                             });
                         });
@@ -229,7 +227,7 @@ function cli_exec(command, type) {
                         });
                         break;
 
-                        // GET IP INFO
+                    // GET IP INFO
                     case 'device_ipaddr':
                         let ipaddr = '';
                         if (!err && command.includes('ping')) {
@@ -261,7 +259,7 @@ function cli_exec(command, type) {
                         }
                         return resolve(ipaddr);
 
-                        // GENERAL IDEVICEDIAGNOSTICS COMMAND
+                    // GENERAL IDEVICEDIAGNOSTICS COMMAND
                     case 'device_command':
                         response.hasError = false;
                         response.result = stdout;

--- a/listener.js
+++ b/listener.js
@@ -14,9 +14,9 @@ var server = express().use(express.json({ limit: "1mb" }));
 
 // DEFINE RESPONSE HEADERS
 server.use(function(req, res, next) {
-  res.header("Access-Control-Allow-Origin", config.domain);
-  res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
-  next();
+    res.header("Access-Control-Allow-Origin", config.domain);
+    res.header("Access-Control-Allow-Headers", "Origin, X-Requested-With, Content-Type, Accept");
+    next();
 });
 
 //------------------------------------------------------------------------------
@@ -25,244 +25,286 @@ server.use(function(req, res, next) {
 var devices = [];
 if (config.manual_list) {
     devices = require("./devices.json");
-    console.log("[DCM] [listener.js] ["+getTime("log")+"] ",devices);
-    console.log("[DCM] [listener.js] ["+getTime("log")+"] Total Devices: "+devices.length);
+    console.log("[DCM] [listener.js] [" + getTime("log") + "] ", devices);
+    console.log("[DCM] [listener.js] [" + getTime("log") + "] Total Devices: " + devices.length);
 }
 else {
-    cli_exec("cfgutil --format JSON list","device_identification");
+    cli_exec("cfgutil --format JSON list", "device_identification");
 }
 
 //------------------------------------------------------------------------------
 //  PAYLOAD PROCESSING
 //------------------------------------------------------------------------------
 server.post("/", (payload, res) => {
-  console.log("[DCM] [listener.js] ["+getTime("log")+"] Received a Payload:",payload.body)
-  let target = payload.body;
-  // GO THROUGH DEVICE ARRAY TO FIND A MATCH
-  devices.forEach( async (device,i) => {
-    switch(target.type){
+    console.log("[DCM] [listener.js] [" + getTime("log") + "] Received a Payload:", payload.body)
+    let target = payload.body;
+    // GO THROUGH DEVICE ARRAY TO FIND A MATCH
+    devices.forEach(async (device, i) => {
+        switch (target.type) {
 
-      // RESTART A DEVICE
-      case "restart":
-        if(device.name == target.device){
-          let restart = await cli_exec(`idevicediagnostics${isWindows() ? ".exe" : ""} -u ${device.uuid} restart`,"device_command");
+            // RESTART A DEVICE
+            case "restart":
+                if (device.name == target.device) {
+                    let restart = await cli_exec(`idevicediagnostics${isWindows() ? ".exe" : ""} -u ${device.uuid} restart`, "device_command");
 
-          // THERE WAS AN ERROR WITH IDEVICEDIAGNOSTICS
-          if(restart.hasError){
-            console.error("[DCM] [listener.js] ["+getTime("log")+"] Failed to Restart "+device.name+" : "+device.uuid+".",restart.error);
+                    // THERE WAS AN ERROR WITH IDEVICEDIAGNOSTICS
+                    if (restart.hasError) {
+                        console.error("[DCM] [listener.js] [" + getTime("log") + "] Failed to Restart " + device.name + " : " + device.uuid + ".", restart.error);
 
-            // SEND ERROR TO DCM
-            res.json({ status: 'error', node: config.name, error:'Failed to restart device.' });
+                        // SEND ERROR TO DCM
+                        res.json({
+                            status: 'error',
+                            node: config.name,
+                            error: 'Failed to restart device.'
+                        });
 
-          // RESTART WAS SUCCESSFUL
-          } else {
-            console.log("[DCM] [listener.js] ["+getTime("log")+"] Restarted "+device.name+" : "+device.uuid+".");
+                        // RESTART WAS SUCCESSFUL
+                    }
+                    else {
+                        console.log("[DCM] [listener.js] [" + getTime("log") + "] Restarted " + device.name + " : " + device.uuid + ".");
 
-            // SEND CONFIRMATION TO DCM
-            res.json({ status: 'ok' });
-          }
+                        // SEND CONFIRMATION TO DCM
+                        res.json({
+                            status: 'ok'
+                        });
+                    }
+                }
+                break;
+
+                // REOPEN THE GAME
+            case "reopen":
+                if (device.name == target.device) {
+                    var ipaddr = '';
+                    if (config.manual_ip) {
+                        ipaddr = device.ipaddr;
+                    }
+                    else {
+                        // Look for WiFi addresses since it's quick
+                        ipaddr = await cli_exec("ping -t 1 " + device.name, 'device_ipaddr');
+                        if (ipaddr == '') {
+                            // Look for tethered addresses and blanks. This takes a while
+                            ipaddr = await cli_exec("grep -A1 \"" + device.name.replace('+', '.*') + "\" /var/db/dhcpd_leases", 'device_ipaddr');
+                        }
+                    }
+                    let reopen = await cli_exec("curl http://" + ipaddr + ":8080/restart", "device_command");
+
+                    // THERE WAS AN ERROR WITH CURL
+                    if (reopen.hasError) {
+                        console.error("[DCM] [listener.js] [" + getTime("log") + "] Failed to reopen game for " + device.name + " : " + device.uuid + ".");
+                        if (reopen.error.toString().includes("Connection refused")) {
+                            console.error("[DCM] [listener.js] [" + getTime("log") + "] The connection was refused to IP " + ipaddr + ".");
+                        }
+                        else {
+                            console.error(reopen.error);
+                        }
+
+                        // SEND ERROR TO DCM
+                        res.json({
+                            status: 'error',
+                            node: config.name,
+                            error: 'Failed to reopen game.'
+                        });
+
+                        // RESTART WAS SUCCESSFUL
+                    }
+                    else {
+                        console.log("[DCM] [listener.js] [" + getTime("log") + "] Reopened the game for " + device.name + " : " + device.uuid + ".");
+
+                        // SEND CONFIRMATION TO DCM
+                        res.json({
+                            status: 'ok'
+                        });
+                    }
+                }
+                break;
+
+                // REAPPLY THE SAM PROFILE
+            case "profile":
+                if (device.name == target.device) {
+                    // REMOVE THE SAM PROFILE
+                    var profile = await cli_exec("cfgutil -e " + device.ecid + " -K org.der -C org.crt remove-profile com.apple.configurator.singleappmode", "device_command");
+                    if (profile.hasError) {
+                        console.error("[DCM] [listener.js] [" + getTime("log") + "] Failed to remove the SAM1 profile from " + device.name + " : " + device.uuid + ".", profile.error);
+                        res.json({
+                            status: 'error',
+                            node: config.name,
+                            error: 'Failed to remove the SAM1 profile.'
+                        });
+                        break;
+                    }
+
+                    // APPLY THE CLOCK PROFILE TO FORCE THE GAME CLOSED
+                    profile = await cli_exec("cfgutil -e " + device.ecid + " -K org.der -C org.crt install-profile sam_clock.mobileconfig", "device_command");
+                    if (profile.hasError) {
+                        console.error("[DCM] [listener.js] [" + getTime("log") + "] Failed to add the SAM_CLOCK profile to " + device.name + " : " + device.uuid + ".", profile.error);
+                        res.json({
+                            status: 'error',
+                            node: config.name,
+                            error: 'Failed to add the SAM_CLOCK profile.'
+                        });
+                        break;
+                    }
+
+                    // REMOVE THE SAM PROFILE AGAIN
+                    profile = await cli_exec("cfgutil -e " + device.ecid + " -K org.der -C org.crt remove-profile com.apple.configurator.singleappmode", "device_command");
+                    if (profile.hasError) {
+                        console.error("[DCM] [listener.js] [" + getTime("log") + "] Failed to remove the SAM2 profile from " + device.name + " : " + device.uuid + ".", profile.error);
+                        res.json({
+                            status: 'error',
+                            node: config.name,
+                            error: 'Failed to remove the SAM2 profile.'
+                        });
+                        break;
+                    }
+
+                    // APPLY THE POGO PROFILE TO RELAUNCH THE GAME
+                    profile = await cli_exec("cfgutil -e " + device.ecid + " -K org.der -C org.crt install-profile sam_pogo.mobileconfig", "device_command");
+                    if (profile.hasError) {
+                        console.error("[DCM] [listener.js] [" + getTime("log") + "] Failed to add the SAM_CALC profile to " + device.name + " : " + device.uuid + ".", profile.error);
+                        res.json({
+                            status: 'error',
+                            node: config.name,
+                            error: 'Failed to add the SAM_POGO profile.'
+                        });
+                        break;
+                    }
+
+                    // REAPPLICATION WAS SUCCESSFUL
+                    console.log("[DCM] [listener.js] [" + getTime("log") + "] Reapplied the SAM profile to " + device.name + " : " + device.uuid + ".");
+                    // SEND CONFIRMATION TO DCM
+                    res.json({
+                        status: 'ok'
+                    });
+                }
+                break;
         }
-        break;
-
-      // REOPEN THE GAME
-      case "reopen":
-        if(device.name == target.device){
-          var ipaddr = '';
-          if (config.manual_ip) {
-              ipaddr = device.ipaddr;
-          }
-          else {
-              // Look for WiFi addresses since it's quick
-              ipaddr = await cli_exec("ping -t 1 "+device.name,'device_ipaddr');
-              if(ipaddr == ''){
-                // Look for tethered addresses and blanks. This takes a while
-                ipaddr = await cli_exec("grep -A1 \""+device.name.replace('+', '.*')+"\" /var/db/dhcpd_leases", 'device_ipaddr');
-              }
-          }
-          let reopen = await cli_exec("curl http://"+ipaddr+":8080/restart","device_command");
-
-          // THERE WAS AN ERROR WITH CURL
-          if(reopen.hasError){
-            console.error("[DCM] [listener.js] ["+getTime("log")+"] Failed to reopen game for "+device.name+" : "+device.uuid+".");
-            if (reopen.error.toString().includes("Connection refused")) {
-                console.error("[DCM] [listener.js] ["+getTime("log")+"] The connection was refused to IP "+ipaddr+".");
-            }
-            else {
-                console.error(reopen.error);
-            }
-
-            // SEND ERROR TO DCM
-            res.json({ status: 'error', node: config.name, error:'Failed to reopen game.' });
-
-          // RESTART WAS SUCCESSFUL
-          } else {
-            console.log("[DCM] [listener.js] ["+getTime("log")+"] Reopened the game for "+device.name+" : "+device.uuid+".");
-
-            // SEND CONFIRMATION TO DCM
-            res.json({ status: 'ok' });
-          }
-        }
-        break;
-
-      // REAPPLY THE SAM PROFILE
-      case "profile":
-        if(device.name == target.device){
-          // REMOVE THE SAM PROFILE
-          var profile = await cli_exec("cfgutil -e "+device.ecid+" -K org.der -C org.crt remove-profile com.apple.configurator.singleappmode","device_command");
-          if(profile.hasError){
-            console.error("[DCM] [listener.js] ["+getTime("log")+"] Failed to remove the SAM1 profile from "+device.name+" : "+device.uuid+".",profile.error);
-            res.json({ status: 'error', node: config.name, error:'Failed to remove the SAM1 profile.' });
-            break;
-          }
-
-          // APPLY THE CLOCK PROFILE TO FORCE THE GAME CLOSED
-          profile = await cli_exec("cfgutil -e "+device.ecid+" -K org.der -C org.crt install-profile sam_clock.mobileconfig","device_command");
-          if(profile.hasError){
-            console.error("[DCM] [listener.js] ["+getTime("log")+"] Failed to add the SAM_CLOCK profile to "+device.name+" : "+device.uuid+".",profile.error);
-            res.json({ status: 'error', node: config.name, error:'Failed to add the SAM_CLOCK profile.' });
-            break;
-          }
-
-          // REMOVE THE SAM PROFILE AGAIN
-          profile = await cli_exec("cfgutil -e "+device.ecid+" -K org.der -C org.crt remove-profile com.apple.configurator.singleappmode","device_command");
-          if(profile.hasError){
-            console.error("[DCM] [listener.js] ["+getTime("log")+"] Failed to remove the SAM2 profile from "+device.name+" : "+device.uuid+".",profile.error);
-            res.json({ status: 'error', node: config.name, error:'Failed to remove the SAM2 profile.' });
-            break;
-          }
-
-          // APPLY THE POGO PROFILE TO RELAUNCH THE GAME
-          profile = await cli_exec("cfgutil -e "+device.ecid+" -K org.der -C org.crt install-profile sam_pogo.mobileconfig","device_command");
-          if(profile.hasError){
-            console.error("[DCM] [listener.js] ["+getTime("log")+"] Failed to add the SAM_CALC profile to "+device.name+" : "+device.uuid+".",profile.error);
-            res.json({ status: 'error', node: config.name, error:'Failed to add the SAM_POGO profile.' });
-            break;
-          }
-
-          // REAPPLICATION WAS SUCCESSFUL
-          console.log("[DCM] [listener.js] ["+getTime("log")+"] Reapplied the SAM profile to "+device.name+" : "+device.uuid+".");
-          // SEND CONFIRMATION TO DCM
-          res.json({ status: 'ok' });
-        }
-        break;
-    }
-  }); return;
+    });
+    return;
 });
 
 //------------------------------------------------------------------------------
 //  COMMAND LINE EXECUTION
 //------------------------------------------------------------------------------
-function cli_exec(command,type){
-  return new Promise( async function(resolve){
-    let response = {};
-    exec(command, async (err, stdout, stderr) => {
-      if(err && !command.includes('ping')){
-        //console.error("[DCM] [listener.js] ["+getTime("log")+"]", err);
-        response.hasError = true;
-        response.error = err;
-        return resolve(response);
-      } else {
-        switch(type){
-
-          // INITIAL DEVICE IDENTIFICATION FOR DEVICE ARRAY
-          case 'device_identification':
-            let data = stdout.split("\n");
-            json = JSON.parse(data[0]);
-            data = json.Output;
-            var forloop = new Promise( async function(resolve, reject){
-              var counter = 0;
-              await Object.keys(data).forEach(async (device) => {
-                if(data[device].deviceType.includes('iPhone') || data[device].deviceType.includes('iPad')){
-                  let device_object = {};
-                  device_object.name = data[device].name;
-                  device_object.uuid = data[device].UDID;
-                  device_object.ecid = data[device].ECID;
-                  devices.push(device_object);
-                  console.log("[DCM] [listener.js] ["+getTime("log")+"] Found Device:", device_object);
-                }
-                if(counter >= Object.keys(data).length -1){
-                  resolve();
-                } else {
-                  counter++
-                }
-              });
-            });
-
-            forloop.then(() => {
-              console.log("[DCM] [listener.js] ["+getTime("log")+"] Total Devices: "+devices.length);
-              return resolve();
-            });
-            break;
-
-          // GET IP INFO
-          case 'device_ipaddr':
-            let ipaddr = '';
-            if(!err && command.includes('ping')){
-              let ping_data = stdout.split("\n");
-              let string_data1 = ping_data[0].split("(");
-              let string_data2 = string_data1[1].split(")");
-              ipaddr = string_data2[0];
+function cli_exec(command, type) {
+    return new Promise(async function(resolve) {
+        let response = {};
+        exec(command, async (err, stdout, stderr) => {
+            if (err && !command.includes('ping')) {
+                //console.error("[DCM] [listener.js] ["+getTime("log")+"]", err);
+                response.hasError = true;
+                response.error = err;
+                return resolve(response);
             }
-            else if(!err) {
-              let ip_line = '';
-              let log_data = stdout.split("\n");
-              for(var line of log_data){
-                if(line.includes("ip_address")){
-                  ip_line = line;
-                  break;
-                }
-              }
-              let ip_strings = ip_line.split("=");
-              for(var line of ip_strings){
-                if(line.includes("192.168.")){
-                  ipaddr = line;
-                  break;
-                }
-              }
-              if(ipaddr == ''){
-                // Rarely, it may still be blank, check the log again
-                ipaddr = await cli_exec(command,'device_ipaddr');
-              }
-            }
-            return resolve(ipaddr);
+            else {
+                switch (type) {
 
-          // GENERAL IDEVICEDIAGNOSTICS COMMAND
-          case 'device_command':
-            response.hasError = false;
-            response.result = stdout;
-            return resolve(response);
-        }
-      }
+                    // INITIAL DEVICE IDENTIFICATION FOR DEVICE ARRAY
+                    case 'device_identification':
+                        let data = stdout.split("\n");
+                        json = JSON.parse(data[0]);
+                        data = json.Output;
+                        var forloop = new Promise(async function(resolve, reject) {
+                            var counter = 0;
+                            await Object.keys(data).forEach(async (device) => {
+                                if (data[device].deviceType.includes('iPhone') || data[device].deviceType.includes('iPad')) {
+                                    let device_object = {};
+                                    device_object.name = data[device].name;
+                                    device_object.uuid = data[device].UDID;
+                                    device_object.ecid = data[device].ECID;
+                                    devices.push(device_object);
+                                    console.log("[DCM] [listener.js] [" + getTime("log") + "] Found Device:", device_object);
+                                }
+                                if (counter >= Object.keys(data).length - 1) {
+                                    resolve();
+                                }
+                                else {
+                                    counter++
+                                }
+                            });
+                        });
+
+                        forloop.then(() => {
+                            console.log("[DCM] [listener.js] [" + getTime("log") + "] Total Devices: " + devices.length);
+                            return resolve();
+                        });
+                        break;
+
+                        // GET IP INFO
+                    case 'device_ipaddr':
+                        let ipaddr = '';
+                        if (!err && command.includes('ping')) {
+                            let ping_data = stdout.split("\n");
+                            let string_data1 = ping_data[0].split("(");
+                            let string_data2 = string_data1[1].split(")");
+                            ipaddr = string_data2[0];
+                        }
+                        else if (!err) {
+                            let ip_line = '';
+                            let log_data = stdout.split("\n");
+                            for (var line of log_data) {
+                                if (line.includes("ip_address")) {
+                                    ip_line = line;
+                                    break;
+                                }
+                            }
+                            let ip_strings = ip_line.split("=");
+                            for (var line of ip_strings) {
+                                if (line.includes("192.168.")) {
+                                    ipaddr = line;
+                                    break;
+                                }
+                            }
+                            if (ipaddr == '') {
+                                // Rarely, it may still be blank, check the log again
+                                ipaddr = await cli_exec(command, 'device_ipaddr');
+                            }
+                        }
+                        return resolve(ipaddr);
+
+                        // GENERAL IDEVICEDIAGNOSTICS COMMAND
+                    case 'device_command':
+                        response.hasError = false;
+                        response.result = stdout;
+                        return resolve(response);
+                }
+            }
+        });
     });
-  });
 }
 
 //------------------------------------------------------------------------------
 //  GET TIME FUNCTION
 //------------------------------------------------------------------------------
-function getTime(type,unix){
-  if(!unix){
-    switch(type){
-      case "log": return Moment().format("hh:mmA");
-      case "24hour": return Moment().format("HH:mm");
-      case "full": return Moment().format("hh:mmA DD-MMM");
+function getTime(type, unix) {
+    if (!unix) {
+        switch (type) {
+            case "log":
+                return Moment().format("hh:mmA");
+            case "24hour":
+                return Moment().format("HH:mm");
+            case "full":
+                return Moment().format("hh:mmA DD-MMM");
+        }
     }
-  } else{
-    switch(type){
-      case "24hour": return Moment.unix(unix).format("HH:mm");
-      case "log": return Moment.unix(unix).format("hh:mmA");
-      case "full": return Moment.unix(unix).format("hh:mmA DD-MMM");
+    else {
+        switch (type) {
+            case "24hour":
+                return Moment.unix(unix).format("HH:mm");
+            case "log":
+                return Moment.unix(unix).format("hh:mmA");
+            case "full":
+                return Moment.unix(unix).format("hh:mmA DD-MMM");
+        }
     }
-  }
 }
 
 //------------------------------------------------------------------------------
 //  GET OS PLATFORM FUNCTION
 //------------------------------------------------------------------------------
 function isWindows() {
-  return os.platform() === "win32";
+    return os.platform() === "win32";
 }
 
 // LISTEN TO THE SPECIFIED PORT FOR TRAFFIC
 server.listen(config.port);
-console.info("[DCM] [listener.js] ["+getTime("log")+"] Now Listening on port "+config.port+".");
+console.info("[DCM] [listener.js] [" + getTime("log") + "] Now Listening on port " + config.port + ".");


### PR DESCRIPTION
This PR contains the code to get an IP address when a reopen request comes in, instead of gathering all of them at the initial launch. This will help with IP changes that happen when a device is rebooted. 

A new config option was added to support a manual list of device info in case people cannot get cfgutil to work. A second config option was added to specify if IP address should be read from the manual list or to allow the script to handle them.

I also formatted the script's spacing so you may want to use the option to ignore whitespace changes if you are reviewing. 