### PR TITLE
Remove SAM Breaks

### DIFF
--- a/listener.js
+++ b/listener.js
@@ -134,7 +134,6 @@ server.post("/", (payload, res) => {
                             node: config.name,
                             error: 'Failed to remove the SAM1 profile.'
                         });
-                        break;
                     }
 
                     // APPLY THE CLOCK PROFILE TO FORCE THE GAME CLOSED
@@ -146,7 +145,6 @@ server.post("/", (payload, res) => {
                             node: config.name,
                             error: 'Failed to add the SAM_CLOCK profile.'
                         });
-                        break;
                     }
 
                     // REMOVE THE SAM PROFILE AGAIN
@@ -158,7 +156,6 @@ server.post("/", (payload, res) => {
                             node: config.name,
                             error: 'Failed to remove the SAM2 profile.'
                         });
-                        break;
                     }
 
                     // APPLY THE POGO PROFILE TO RELAUNCH THE GAME


### PR DESCRIPTION
This is just to allow DCMRL the ability to apply the SAM profile on devices that may have had the profile removed already. The `break`s would stop it at the error and this will just continue after the errors since they can be ignored in this case. 