### PR TITLE
Provide option to use ios-deploy

### DIFF
--- a/config.example.json
+++ b/config.example.json
@@ -3,5 +3,6 @@
     "port": 6542,
     "domain": "http://YOUR-DOMAIN.TLD",
     "manual_list": false,
-    "manual_ip": false
+    "manual_ip": false,
+    "use_ios_deploy": false
 }

--- a/listener.js
+++ b/listener.js
@@ -263,7 +263,7 @@ function cli_exec(command, type) {
                             var forloop = new Promise(async function(resolve, reject) {
                                 var counter = 0;
                                 await data.forEach(async (device,i) => {
-                                    if((device.includes('iPhone') || device.includes('iPad')) && !devices.some(d=>d.uuid===device.split(" ")[2])) {
+                                    if (device.match(/iPhone|iPad|iPod/g) && !devices.some(d => d.uuid === device.split(' ')[2])) {
                                         let device_object = {};
                                         device_object.name = device.split("'")[1];
                                         device_object.uuid = device.split(" ")[2];
@@ -285,7 +285,7 @@ function cli_exec(command, type) {
                             var forloop = new Promise(async function(resolve, reject) {
                                 var counter = 0;
                                 await Object.keys(data).forEach(async (device) => {
-                                    if (data[device].deviceType.includes('iPhone') || data[device].deviceType.includes('iPad')) {
+                                    if (data[device].deviceType.match(/iPhone|iPad|iPod/g)) {
                                         let device_object = {};
                                         device_object.name = data[device].name;
                                         device_object.uuid = data[device].UDID;

--- a/listener.js
+++ b/listener.js
@@ -126,7 +126,7 @@ server.post("/", (payload, res) => {
 
             // REAPPLY THE SAM PROFILE
             case "profile":
-                if (device.name == target.device) {
+                if (!config.use_ios_deploy && device.name == target.device) {
                     // REMOVE THE SAM PROFILE
                     var profile = await cli_exec("cfgutil -e " + device.ecid + " -K org.der -C org.crt remove-profile com.apple.configurator.singleappmode", "device_command");
                     if (profile.hasError) {


### PR DESCRIPTION
For those of us running older MacOS and Xcode, this will give the option of using the older method of getting the attached devices (i.e., using ios-deploy). This is enabled using a new config entry ("use_ios_deploy": true). I don't believe this change will disrupt current functionality but I don't have any way to test because all I have are old macs that can't use cfgutil.