### PR TITLE
feat: Basic android support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@
 "use_ios_deploy" = True/False for using ios-deploy instead of cfgutil for querying devices (disables the profile command).
 ```
 
+## Android support
+There is limited support for using Android devices. If a mitm client sends their status to RDM we can use the same logic to trigger reboots. Currently you can use the `manual_list: true` to supply a custom script via `reboot_cmd` to reboot devices. Since power relays can be triggered via http calls, custom API methods, and are unique per vendor this is a batteries not included option.
+
+Game restarts, SAM, etc do not apply to these devices and error messages can be ignored.
+
+For iOS devices please leave `reboot_cmd` empty or delete the line!
+
 ## Troubleshooting
 If the cfgutil from AC2 does not list any devices when you use the `cfgutil list` command, then you may need to upgrade AC2 and reinstall the automation tools.
 

--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@
 ```
 
 ## Android support
-There is limited support for using Android devices. If a mitm client sends their status to RDM we can use the same logic to trigger reboots. Currently you can use the `manual_list: true` to supply a custom script via `reboot_cmd` to reboot devices. Since power relays can be triggered via http calls, custom API methods, and are unique per vendor this is a batteries not included option.
+If a mitm client sends their status to RDM we can use the same logic to trigger reboots via the `rebootMonitorURL` endpoint. Currently you must use the `manual_list: true` to supply a custom script via the `reboot_cmd` option to reboot devices. All other endpoints (`reopenMonitorURL`, `reapplySAMMonitorURL`, `brightnessMonitorURL`) are not supported since they are iOS specific. Power relays can be triggered via http calls, custom API methods, and are unique per vendor as such this is a batteries not included option.
 
-Game restarts, SAM, etc do not apply to these devices and error messages can be ignored.
+It is recommended that you setup multiple DCMRL instances if running iOS and Android on the same host machine. This allows you to keep the automatic iOS device list detection plus reopen, reapply sam, and brightness commands can all point to one instance. Then Android devices will only receive the reboot commands keeping for clean logs.
 
 For iOS devices please leave `reboot_cmd` empty or delete the line!
 

--- a/devices.example.json
+++ b/devices.example.json
@@ -6,6 +6,13 @@
     "ipaddr":"192.168.1.1"
   },
   {
+    "name":"atv-01",
+    "uuid":"",
+    "ecid":"",
+    "ipaddr":"192.168.1.1",
+    "reboot_cmd": "./custom_reboot.sh atv-01"
+  },
+  {
     "name":"002-SE",
     "uuid":"f0axxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx9af",
     "ecid":"0x9000000000006",

--- a/listener.js
+++ b/listener.js
@@ -47,7 +47,12 @@ server.post("/", (payload, res) => {
             // RESTART A DEVICE
             case "restart":
                 if (device.name == target.device) {
-                    let restart = await cli_exec(`idevicediagnostics${isWindows() ? ".exe" : ""} -u ${device.uuid} restart`, "device_command");
+                    if (device.reboot_cmd) {
+                        var command = device.reboot_cmd
+                    } else {
+                        var command = `idevicediagnostics${isWindows() ? ".exe" : ""} -u ${device.uuid} restart`
+                    }
+                    let restart = await cli_exec(command, "device_command");
 
                     // THERE WAS AN ERROR WITH IDEVICEDIAGNOSTICS
                     if (restart.hasError) {


### PR DESCRIPTION
This adds android support so we can reboot devices connecting into RDM. Right now this only adds the `reboot` command via a custom script/command that users must provide. Since power relays are quite unique for each vendor this will require users provide the final glue to connect all the pieces. 

I'm sure you've heard but there is a new Android mitm client which is why this enhancement is quite nice to have. Since reboot is the only option available for non-ios devices I didn't touch any of the other commands. SAM, game restart, etc will likely output some warning messages for users but they can be ignored. 

Please let me know if there is anything you'd like changed.

Quick example
<details>
<code>
curl -d '{"type":"restart", "device":"atv-01"}' -H "Content-Type: application/json" -X POST http://localhost:6542/
</code>
<br><br>
<code>
[DCM] [listener.js] [11:27PM] Received a Payload: { type: 'restart', device: 'atv-01' }
</code>
</details>
