### PR TITLE
Support Remote Command Execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,14 +39,13 @@
 "manual_list" = True/False for creating your own JSON list of devices as device.json. See device.example.json.
 "manual_ip" = True/False for adding the IP to the device.json or to allow the script to find IPs.
 "use_ios_deploy" = True/False for using ios-deploy instead of cfgutil for querying devices (disables the profile command).
+"allow_cmds" = True/False for allowing the execution of local commands that are defined in "cmds".
+"cmds" = An array of objects that contain the "alias" (required), "command" (required), and "description" (optional).
+         "alias" is the name that you can send to the listener to execute a command without typing the full command.
+         "command" is a string used to hold the command and its parameters. Note that you should use nohup if the command's error output is larger than 200kb like Redux.
+         "description" is a string that you can use to keep notes about your command.
+         Note that passing parameters or using sudo are not supported as these open your system to attacks.
 ```
-
-## Android support
-If a mitm client sends their status to RDM we can use the same logic to trigger reboots via the `rebootMonitorURL` endpoint. Currently you must use the `manual_list: true` to supply a custom script via the `reboot_cmd` option to reboot devices. All other endpoints (`reopenMonitorURL`, `reapplySAMMonitorURL`, `brightnessMonitorURL`) are not supported since they are iOS specific. Power relays can be triggered via http calls, custom API methods, and are unique per vendor as such this is a batteries not included option.
-
-It is recommended that you setup multiple DCMRL instances if running iOS and Android on the same host machine. This allows you to keep the automatic iOS device list detection plus reopen, reapply sam, and brightness commands can all point to one instance. Then Android devices will only receive the reboot commands keeping for clean logs.
-
-For iOS devices please leave `reboot_cmd` empty or delete the line!
 
 ## Troubleshooting
 If the cfgutil from AC2 does not list any devices when you use the `cfgutil list` command, then you may need to upgrade AC2 and reinstall the automation tools.

--- a/README.md
+++ b/README.md
@@ -45,7 +45,15 @@
          "command" is a string used to hold the command and its parameters. Note that you should use nohup if the command's error output is larger than 200kb like Redux.
          "description" is a string that you can use to keep notes about your command.
          Note that passing parameters or using sudo are not supported as these open your system to attacks.
+
 ```
+
+## Android support
+If a mitm client sends their status to RDM we can use the same logic to trigger reboots via the `rebootMonitorURL` endpoint. Currently you must use the `manual_list: true` to supply a custom script via the `reboot_cmd` option to reboot devices. All other endpoints (`reopenMonitorURL`, `reapplySAMMonitorURL`, `brightnessMonitorURL`) are not supported since they are iOS specific. Power relays can be triggered via http calls, custom API methods, and are unique per vendor as such this is a batteries not included option.
+
+It is recommended that you setup multiple DCMRL instances if running iOS and Android on the same host machine. This allows you to keep the automatic iOS device list detection plus reopen, reapply sam, and brightness commands can all point to one instance. Then Android devices will only receive the reboot commands keeping for clean logs.
+
+For iOS devices please leave `reboot_cmd` empty or delete the line!
 
 ## Troubleshooting
 If the cfgutil from AC2 does not list any devices when you use the `cfgutil list` command, then you may need to upgrade AC2 and reinstall the automation tools.

--- a/config.example.json
+++ b/config.example.json
@@ -4,5 +4,18 @@
     "domain": "http://YOUR-DOMAIN.TLD",
     "manual_list": false,
     "manual_ip": false,
-    "use_ios_deploy": false
+    "use_ios_deploy": false,
+    "allow_cmds": false,
+    "cmds": [
+        {
+            "alias": "1",
+            "command": "pwd",
+            "description": "The pwd command prints the working directory"
+        },
+        {
+            "alias": "redux_1",
+            "command": "cd ~/redux/ && nohup ./redux.js -f",
+            "description": "This command changes to the Redux directory and executes Redux with the full auto parameter. Output is sent to nohup.out so the listener can avoid buffer overflows"
+        }
+    ]
 }


### PR DESCRIPTION
Update to support the execution of pre-define commands. Takes the type of `cmd` to identify the command alias to execute. Since this can be a big security risk, only pre-define commands are allowed and no parameters are taken by the listener. All parameters need to be set in the config file. There are buffer limits to to errors that this can handle. If you can receive over 200kb of errors, use the nohup command before your command so it outputs to nohup.out in the executing directory.

Use the bool to disable/enable to option to allow remote command execution.

See the example file for remotely executing Redux.

See RDMM #[19](https://github.com/Kneckter/RDMMonitor/pull/19) for the related PR to support this update.